### PR TITLE
JMS: latest versions; avoid pre-emptive shutdown

### DIFF
--- a/alpakka-sample-jms/build.sbt
+++ b/alpakka-sample-jms/build.sbt
@@ -3,4 +3,4 @@ version := "1.3.0"
 scalaVersion := Dependencies.scalaVer
 libraryDependencies ++= Dependencies.dependencies
 // Having JBoss as a first resolver is a workaround for https://github.com/coursier/coursier/issues/200
-externalResolvers := ("jboss" at "http://repository.jboss.org/nexus/content/groups/public") +: externalResolvers.value
+externalResolvers := ("jboss" at "https://repository.jboss.org/nexus/content/groups/public") +: externalResolvers.value

--- a/alpakka-sample-jms/project/Dependencies.scala
+++ b/alpakka-sample-jms/project/Dependencies.scala
@@ -1,11 +1,11 @@
 import sbt._
 
 object Dependencies {
-  val scalaVer = "2.12.9"
+  val scalaVer = "2.13.1"
   // #deps
-  val AkkaVersion = "2.6.1"
-  val AkkaHttpVersion = "10.1.10"
-  val AlpakkaVersion = "1.1.0"
+  val AkkaVersion = "2.6.4"
+  val AkkaHttpVersion = "10.1.11"
+  val AlpakkaVersion = "2.0.0-RC1"
 
   // #deps
 

--- a/alpakka-sample-jms/project/build.properties
+++ b/alpakka-sample-jms/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.3
+sbt.version=1.3.9

--- a/alpakka-sample-jms/src/main/java/samples/javadsl/JmsToFile.java
+++ b/alpakka-sample-jms/src/main/java/samples/javadsl/JmsToFile.java
@@ -27,6 +27,7 @@ import javax.jms.ConnectionFactory;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
 
 // #sample
 
@@ -75,8 +76,10 @@ public class JmsToFile {
     JmsConsumerControl runningSource = pair.first();
     CompletionStage<IOResult> streamCompletion = pair.second();
 
+    Thread.sleep(4000);
+
     runningSource.shutdown();
     streamCompletion.thenAccept(res -> system.terminate());
-    system.getWhenTerminated().thenAccept(t -> activeMqBroker.stop(ec));
+    system.getWhenTerminated().thenCompose(t -> activeMqBroker.stopCs(ec)).toCompletableFuture().get(5, TimeUnit.SECONDS);
   }
 }

--- a/alpakka-sample-jms/src/main/java/samples/javadsl/JmsToHttpGet.java
+++ b/alpakka-sample-jms/src/main/java/samples/javadsl/JmsToHttpGet.java
@@ -29,6 +29,7 @@ import scala.concurrent.ExecutionContext;
 import javax.jms.ConnectionFactory;
 import java.util.Arrays;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
 
 // #sample
 
@@ -86,10 +87,10 @@ public class JmsToHttpGet {
     streamCompletion.thenAccept(res -> system.terminate());
     system
         .getWhenTerminated()
-        .thenAccept(
+        .thenCompose(
             t -> {
               webserver.stop();
-              activeMqBroker.stop(ec);
-            });
+              return activeMqBroker.stopCs(ec);
+            }).toCompletableFuture().get(5, TimeUnit.SECONDS);
   }
 }

--- a/alpakka-sample-jms/src/main/java/samples/javadsl/JmsToOneFilePerMessage.java
+++ b/alpakka-sample-jms/src/main/java/samples/javadsl/JmsToOneFilePerMessage.java
@@ -29,6 +29,7 @@ import javax.jms.ConnectionFactory;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
 
 // #sample
 
@@ -88,6 +89,6 @@ public class JmsToOneFilePerMessage {
 
     runningSource.shutdown();
     streamCompletion.thenAccept(res -> system.terminate());
-    system.getWhenTerminated().thenAccept(t -> activeMqBroker.stop(ec));
+    system.getWhenTerminated().thenCompose(t -> activeMqBroker.stopCs(ec)).toCompletableFuture().get(5, TimeUnit.SECONDS);
   }
 }

--- a/alpakka-sample-jms/src/main/java/samples/javadsl/JmsToWebSocket.java
+++ b/alpakka-sample-jms/src/main/java/samples/javadsl/JmsToWebSocket.java
@@ -35,6 +35,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
 
 // #sample
 
@@ -112,11 +113,11 @@ public class JmsToWebSocket {
     streamCompletion.thenAccept(res -> system.terminate());
     system
         .getWhenTerminated()
-        .thenAccept(
+        .thenCompose(
             t -> {
               webserver.stop();
-              activeMqBroker.stop(ec);
-            });
+              return activeMqBroker.stopCs(ec);
+            }).toCompletableFuture().get(5, TimeUnit.SECONDS);
   }
 
   // #sample

--- a/alpakka-sample-jms/src/main/scala/playground/ActiveMqBroker.scala
+++ b/alpakka-sample-jms/src/main/scala/playground/ActiveMqBroker.scala
@@ -4,12 +4,15 @@
 
 package playground
 
+import java.util.concurrent.CompletionStage
+
 import akka.Done
 import javax.jms.ConnectionFactory
 import org.apache.activemq.ActiveMQConnectionFactory
 import org.apache.activemq.broker.BrokerService
 
 import scala.concurrent.{ExecutionContext, Future}
+import scala.compat.java8.FutureConverters._
 
 /**
   * To start an ActiveMQ broker be sure to include these dependencies:
@@ -29,6 +32,8 @@ class ActiveMqBroker {
     brokerService = Some(broker)
     broker
   }
+
+  def stopCs(ec: ExecutionContext): CompletionStage[Done] = stop()(ec).toJava
 
   def stop()(implicit ec: ExecutionContext): Future[Done] =
     brokerService.fold(Future.successful(Done)) { broker =>


### PR DESCRIPTION
* Scala 2.13.1
* Akka 2.6.4
* Akka HTTP 10.1.11
* Alpakka 2.0.0-RC1

References https://github.com/akka/alpakka/issues/2228 which turned out to be caused by the JMS broker shutting down during initalisation.
