### PR TITLE
Upgrade dependencies.

### DIFF
--- a/alpakka-sample-kafka-to-websocket-clients/README.md
+++ b/alpakka-sample-kafka-to-websocket-clients/README.md
@@ -2,11 +2,12 @@
 
 ## Read from a Kafka topic and push the data to connected websocket clients
 
-Clients may connect via websockets and will receive data read from a Kafka topic. The websockets are implemented in @extref[Akka HTTP](akka-http:) and [Alpakka Kafka](alpakka-kafka:) subscribes to the Kafka topic.
+Clients may connect via websockets and will receive data read from a Kafka topic. The websockets are implemented 
+in [Akka HTTP](https://doc.akka.io/docs/akka-http/current/introduction.html) and [Alpakka Kafka](https://doc.akka.io/docs/alpakka-kafka/current/) subscribes to the Kafka topic.
 
-Browse the sources at @link:[Github](https://github.com/akka/alpakka-samples/tree/master/alpakka-sample-kafka-to-websocket-clients) { open=new }.
+Browse the sources at [Github](https://github.com/akka/alpakka-samples/tree/master/alpakka-sample-kafka-to-websocket-clients) { open=new }.
 
-To try out this project clone @link:[the Alpakka Samples repository](https://github.com/akka/alpakka-samples) { open=new } and find it in the `alpakka-sample-kafka-to-websocket-clients` directory.
+To try out this project clone [the Alpakka Samples repository](https://github.com/akka/alpakka-samples) { open=new } and find it in the `alpakka-sample-kafka-to-websocket-clients` directory.
 
 ## Running
 
@@ -16,7 +17,8 @@ The sample spawns a test Kafka server with docker.
 sbt "runMain samples.javadsl.Main"
 ```
 
-You can connect to ws://127.0.0.1/events to receive messages over websockets. E.g. Using [`websocat`](https://github.com/vi/websocat) as a simple WS client.
+You can connect to `ws://127.0.0.1/events` to receive messages over websockets.
+E.g. Using [`websocat`](https://github.com/vi/websocat) as a simple WS client.
 
 To listen to events coming in on the websocket use `websocat` to connect to the `/events` endpoint.
 

--- a/alpakka-sample-kafka-to-websocket-clients/project/Dependencies.scala
+++ b/alpakka-sample-kafka-to-websocket-clients/project/Dependencies.scala
@@ -3,9 +3,9 @@ import sbt._
 object Dependencies {
   val scalaVer = "2.13.7"
   // #deps
-  val AkkaVersion = "2.6.19"
-  val AkkaHttpVersion = "10.1.12"
-  val AlpakkaKafkaVersion = "3.0.1"
+  val AkkaVersion = "2.7.0"
+  val AkkaHttpVersion = "10.4.0"
+  val AlpakkaKafkaVersion = "4.0.0"
   // #deps
   val dependencies = List(
     // #deps
@@ -18,7 +18,7 @@ object Dependencies {
     "ch.qos.logback" % "logback-classic" % "1.2.3",
     // #deps
 
-    "org.testcontainers" % "kafka" % "1.14.3",
+    "org.testcontainers" % "kafka" % "1.17.5",
 
     "com.typesafe.akka" %% "akka-stream-testkit" % AkkaVersion % Test,
     "com.google.guava" % "guava" % "28.2-jre" % Test,

--- a/alpakka-sample-kafka-to-websocket-clients/src/main/java/samples/javadsl/Helper.java
+++ b/alpakka-sample-kafka-to-websocket-clients/src/main/java/samples/javadsl/Helper.java
@@ -11,6 +11,7 @@ import org.apache.kafka.common.serialization.StringSerializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.utility.DockerImageName;
 
 import java.util.concurrent.CompletionStage;
 
@@ -25,7 +26,7 @@ public class Helper {
     }
 
     public void startContainers() {
-        kafka = new KafkaContainer("5.1.2"); // contains Kafka 2.1.x
+        kafka = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.3.0"));
         kafka.start();
         kafkaBootstrapServers = kafka.getBootstrapServers();
     }


### PR DESCRIPTION
<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
Without this upgrade, you run into testcontainers/docker related errors that are confusing or red herrings (like `ContainerFetchException: Can't get Docker image`, when the image is actually available)
